### PR TITLE
Add possibility to use custom buttons when using the SubGHz remote

### DIFF
--- a/catalog/docs/Readme.md
+++ b/catalog/docs/Readme.md
@@ -12,7 +12,7 @@ After launching the application, you will see the MAP file selection screen (fil
     - On remote screen, use the navigation buttons(D-pad) to send a signal
 - Edit Map File - map file editor
     - Select map file 
-    - Up/Down - slot nafigation
+    - Up/Down - slot navigation
     - Ok - edit menu
     - Left - preview/save
 - New Map File - Creating a new map file

--- a/helpers/subrem_custom_button_info.h
+++ b/helpers/subrem_custom_button_info.h
@@ -1,0 +1,12 @@
+#pragma once
+
+enum CustomButton {
+    ButtonOK,
+    ButtonUp,
+    ButtonDown,
+    ButtonLeft,
+    ButtonRight,
+    NumButtons
+};
+
+extern const char* const custom_button_text[NumButtons];

--- a/helpers/subrem_custom_event.h
+++ b/helpers/subrem_custom_event.h
@@ -18,9 +18,9 @@ typedef enum {
 #endif
     // SubmenuIndexSubRemAbout,
 
-    // EditSubmenuIndex
-    EditSubmenuIndexEditLabel,
-    EditSubmenuIndexEditFile,
+    // Submenu enter selection
+    SubRemCustomEventEnterEditLabel,
+    SubRemCustomEventEnterEditFile,
 
     // SubRemCustomEvent
     SubRemCustomEventViewRemoteStartUP = 100,
@@ -38,10 +38,14 @@ typedef enum {
     SubRemCustomEventViewEditMenuEdit,
     SubRemCustomEventViewEditMenuSave,
 
-    SubRemCustomEventSceneEditsubmenu,
+    SubRemCustomEventSceneEditSubmenu,
     SubRemCustomEventSceneEditLabelInputDone,
-    SubRemCustomEventSceneEditLabelWidgetAcces,
+    SubRemCustomEventSceneEditLabelWidgetAccess,
     SubRemCustomEventSceneEditLabelWidgetBack,
+    SubRemCustomEventSceneEditButtonInputDone,
+    SubRemCustomEventSceneEditButtonWidgetAccess,
+    SubRemCustomEventSceneEditButtonWidgetBack,
+
 
     SubRemCustomEventSceneEditOpenSubErrorPopup,
 
@@ -56,3 +60,9 @@ typedef enum {
 #endif
 
 } SubRemCustomEvent;
+
+typedef enum {
+    EditSubmenuIndexEditLabel,
+    EditSubmenuIndexEditFile,
+    EditSubmenuIndexEditButton,
+} SubRemEditSubmenuIndex;

--- a/helpers/subrem_presets.c
+++ b/helpers/subrem_presets.c
@@ -7,8 +7,9 @@ SubRemSubFilePreset* subrem_sub_file_preset_alloc(void) {
 
     sub_preset->fff_data = flipper_format_string_alloc();
     sub_preset->file_path = furi_string_alloc();
-    sub_preset->protocaol_name = furi_string_alloc();
+    sub_preset->protocol_name = furi_string_alloc();
     sub_preset->label = furi_string_alloc();
+    sub_preset->button = 0;
 
     sub_preset->freq_preset.name = furi_string_alloc();
 
@@ -22,7 +23,7 @@ void subrem_sub_file_preset_free(SubRemSubFilePreset* sub_preset) {
     furi_assert(sub_preset);
 
     furi_string_free(sub_preset->label);
-    furi_string_free(sub_preset->protocaol_name);
+    furi_string_free(sub_preset->protocol_name);
     furi_string_free(sub_preset->file_path);
     flipper_format_free(sub_preset->fff_data);
 
@@ -35,8 +36,9 @@ void subrem_sub_file_preset_reset(SubRemSubFilePreset* sub_preset) {
     furi_assert(sub_preset);
 
     furi_string_set_str(sub_preset->label, "");
-    furi_string_reset(sub_preset->protocaol_name);
+    furi_string_reset(sub_preset->protocol_name);
     furi_string_reset(sub_preset->file_path);
+    sub_preset->button = 0;
 
     Stream* fff_data_stream = flipper_format_get_raw_stream(sub_preset->fff_data);
     stream_clean(fff_data_stream);
@@ -168,7 +170,7 @@ SubRemLoadSubState subrem_sub_preset_load(
                 break;
             }
 
-            furi_string_set(sub_preset->protocaol_name, temp_str);
+            furi_string_set(sub_preset->protocol_name, temp_str);
         } else {
             FURI_LOG_E(TAG, "Protocol does not support transmission");
             break;

--- a/helpers/subrem_presets.h
+++ b/helpers/subrem_presets.h
@@ -17,8 +17,9 @@ typedef struct {
     FlipperFormat* fff_data;
     FreqPreset freq_preset;
     FuriString* file_path;
-    FuriString* protocaol_name;
+    FuriString* protocol_name;
     FuriString* label;
+    uint8_t button;
     SubGhzProtocolType type;
     SubRemLoadSubState load_state;
 } SubRemSubFilePreset;

--- a/helpers/subrem_types.h
+++ b/helpers/subrem_types.h
@@ -18,6 +18,7 @@ typedef enum {
 
 typedef enum {
     SubRemViewIDSubmenu,
+    SubRemViewIDVariableItemList,
     SubRemViewIDWidget,
     SubRemViewIDPopup,
     SubRemViewIDTextInput,

--- a/helpers/txrx/subghz_txrx.h
+++ b/helpers/txrx/subghz_txrx.h
@@ -184,6 +184,29 @@ void subghz_txrx_hopper_unpause(SubGhzTxRx* instance);
 void subghz_txrx_hopper_pause(SubGhzTxRx* instance);
 
 /**
+ * Get button
+ *
+ * @param instance Pointer to a SubGhzTxRx
+ * @return Button id
+ */
+uint8_t subghz_txrx_custom_button_get(SubGhzTxRx* instance);
+
+/**
+ * Set button
+ *
+ * @param instance Pointer to a SubGhzTxRx
+ * @param button Button id
+ */
+void subghz_txrx_custom_button_set(SubGhzTxRx* instance, uint8_t button);
+
+/**
+ * Reset button
+ *
+ * @param instance Pointer to a SubGhzTxRx
+ */
+void subghz_txrx_custom_button_reset(SubGhzTxRx* instance);
+
+/**
  * Speaker on
  * 
  * @param instance Pointer to a SubGhzTxRx 

--- a/helpers/txrx/subghz_txrx_i.h
+++ b/helpers/txrx/subghz_txrx_i.h
@@ -19,6 +19,8 @@ struct SubGhzTxRx {
     bool is_database_loaded;
     SubGhzHopperState hopper_state;
 
+    uint8_t custom_button;
+
     SubGhzTxRxState txrx_state;
     SubGhzSpeakerState speaker_state;
     const SubGhzDevice* radio_device;

--- a/scenes/subrem_scene_edit_label.c
+++ b/scenes/subrem_scene_edit_label.c
@@ -19,7 +19,7 @@ void subrem_scene_edit_label_widget_callback(GuiButtonType result, InputType typ
     SubGhzRemoteApp* app = context;
     if((result == GuiButtonTypeCenter) && (type == InputTypeShort)) {
         view_dispatcher_send_custom_event(
-            app->view_dispatcher, SubRemCustomEventSceneEditLabelWidgetAcces);
+            app->view_dispatcher, SubRemCustomEventSceneEditLabelWidgetAccess);
     } else if((result == GuiButtonTypeLeft) && (type == InputTypeShort)) {
         view_dispatcher_send_custom_event(
             app->view_dispatcher, SubRemCustomEventSceneEditLabelWidgetBack);
@@ -107,7 +107,7 @@ bool subrem_scene_edit_label_on_event(void* context, SceneManagerEvent event) {
                 scene_manager_previous_scene(app->scene_manager);
             }
             return true;
-        } else if(event.event == SubRemCustomEventSceneEditLabelWidgetAcces) {
+        } else if(event.event == SubRemCustomEventSceneEditLabelWidgetAccess) {
             furi_string_set(label, app->file_name_tmp);
             app->map_not_saved = true;
             scene_manager_previous_scene(app->scene_manager);

--- a/scenes/subrem_scene_edit_menu.c
+++ b/scenes/subrem_scene_edit_menu.c
@@ -45,6 +45,7 @@ static void subrem_scene_edit_menu_update_data(SubGhzRemoteApp* app) {
         index,
         app->map_preset->subs_preset[index]->label,
         app->map_preset->subs_preset[index]->file_path,
+        app->map_preset->subs_preset[index]->button,
         app->map_preset->subs_preset[index]->load_state);
 }
 

--- a/scenes/subrem_scene_edit_submenu.c
+++ b/scenes/subrem_scene_edit_submenu.c
@@ -1,10 +1,19 @@
 #include "../subghz_remote_app_i.h"
 #include "../helpers/subrem_custom_event.h"
+#include "../helpers/subrem_custom_button_info.h"
+
+const char* const custom_button_text[NumButtons] = {
+    "Default",
+    "Up",
+    "Down",
+    "Left",
+    "Right"
+};
 
 void subrem_scene_edit_submenu_text_input_callback(void* context) {
     furi_assert(context);
     SubGhzRemoteApp* app = context;
-    view_dispatcher_send_custom_event(app->view_dispatcher, SubRemCustomEventSceneEditsubmenu);
+    view_dispatcher_send_custom_event(app->view_dispatcher, SubRemCustomEventSceneEditSubmenu);
 }
 
 void subrem_scene_edit_submenu_callback(void* context, uint32_t index) {
@@ -12,19 +21,45 @@ void subrem_scene_edit_submenu_callback(void* context, uint32_t index) {
     SubGhzRemoteApp* app = context;
 
     view_dispatcher_send_custom_event(app->view_dispatcher, index);
+    if(index == EditSubmenuIndexEditLabel) {
+        view_dispatcher_send_custom_event(app->view_dispatcher, SubRemCustomEventEnterEditLabel);
+    } else if(index == EditSubmenuIndexEditFile) {
+        view_dispatcher_send_custom_event(app->view_dispatcher, SubRemCustomEventEnterEditFile);
+    }
+}
+
+void subrem_scene_edit_submenu_var_list_change_callback(VariableItem* item) {
+    furi_assert(item);
+    SubGhzRemoteApp* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    variable_item_set_current_value_text(item, custom_button_text[index]);
+    SubRemSubFilePreset *sub_preset = app->map_preset->subs_preset[app->chosen_sub];
+    sub_preset->button = index;
 }
 
 void subrem_scene_edit_submenu_on_enter(void* context) {
     furi_assert(context);
 
     SubGhzRemoteApp* app = context;
-    Submenu* submenu = app->submenu;
-    submenu_add_item(
-        submenu, "Edit Label", EditSubmenuIndexEditLabel, subrem_scene_edit_submenu_callback, app);
-    submenu_add_item(
-        submenu, "Edit File", EditSubmenuIndexEditFile, subrem_scene_edit_submenu_callback, app);
+    VariableItemList* var_item_list = app->var_item_list;
+    VariableItem* item;
 
-    view_dispatcher_switch_to_view(app->view_dispatcher, SubRemViewIDSubmenu);
+    SubRemSubFilePreset* sub_preset = app->map_preset->subs_preset[app->chosen_sub];
+    variable_item_list_set_enter_callback(
+            var_item_list, subrem_scene_edit_submenu_callback, app);
+
+    variable_item_list_add(var_item_list, "Edit Label", 0, NULL, NULL);
+    variable_item_list_add(var_item_list, "Edit File", 0, NULL, NULL);
+    item = variable_item_list_add(var_item_list, "Button", NumButtons, subrem_scene_edit_submenu_var_list_change_callback, app);
+
+    variable_item_set_current_value_index(item, sub_preset->button);
+    variable_item_set_current_value_text(item, custom_button_text[sub_preset->button]);
+
+    variable_item_list_set_selected_item(
+        var_item_list, scene_manager_get_scene_state(app->scene_manager, SubRemSceneEditSubMenu));
+
+    view_dispatcher_switch_to_view(app->view_dispatcher, SubRemViewIDVariableItemList);
 }
 
 bool subrem_scene_edit_submenu_on_event(void* context, SceneManagerEvent event) {
@@ -34,10 +69,10 @@ bool subrem_scene_edit_submenu_on_event(void* context, SceneManagerEvent event) 
     bool consumed = false;
 
     if(event.type == SceneManagerEventTypeCustom) {
-        if(event.event == EditSubmenuIndexEditLabel) {
+        if(event.event == SubRemCustomEventEnterEditLabel) {
             scene_manager_next_scene(app->scene_manager, SubRemSceneEditLabel);
             consumed = true;
-        } else if(event.event == EditSubmenuIndexEditFile) {
+        } else if(event.event == SubRemCustomEventEnterEditFile) {
             scene_manager_next_scene(app->scene_manager, SubRemSceneOpenSubFile);
             consumed = true;
         }
@@ -50,5 +85,5 @@ void subrem_scene_edit_submenu_on_exit(void* context) {
     furi_assert(context);
 
     SubGhzRemoteApp* app = context;
-    submenu_reset(app->submenu);
+    variable_item_list_reset(app->var_item_list);
 }

--- a/scenes/subrem_scene_enter_new_name.c
+++ b/scenes/subrem_scene_enter_new_name.c
@@ -61,6 +61,7 @@ void subrem_scene_enter_new_name_on_exit(void* context) {
 
     SubGhzRemoteApp* app = context;
     submenu_reset(app->submenu);
+    variable_item_list_reset(app->var_item_list);
 
     // Clear validator & view
     void* validator_context = text_input_get_validator_callback_context(app->text_input);

--- a/subghz_remote_app.c
+++ b/subghz_remote_app.c
@@ -68,6 +68,11 @@ SubGhzRemoteApp* subghz_remote_app_alloc() {
     view_dispatcher_add_view(
         app->view_dispatcher, SubRemViewIDSubmenu, submenu_get_view(app->submenu));
 
+    // Variable item list
+    app->var_item_list = variable_item_list_alloc();
+    view_dispatcher_add_view(
+        app->view_dispatcher, SubRemViewIDVariableItemList, variable_item_list_get_view(app->var_item_list));
+
     // Dialog
     app->dialogs = furi_record_open(RECORD_DIALOGS);
 
@@ -121,6 +126,10 @@ void subghz_remote_app_free(SubGhzRemoteApp* app) {
     // Submenu
     view_dispatcher_remove_view(app->view_dispatcher, SubRemViewIDSubmenu);
     submenu_free(app->submenu);
+
+    // Variable item list
+    view_dispatcher_remove_view(app->view_dispatcher, SubRemViewIDVariableItemList);
+    variable_item_list_free(app->var_item_list);
 
     // Dialog
     furi_record_close(RECORD_DIALOGS);

--- a/subghz_remote_app_i.c
+++ b/subghz_remote_app_i.c
@@ -1,5 +1,7 @@
 #include "subghz_remote_app_i.h"
+#include "helpers/txrx/subghz_txrx_i.h"
 #include <lib/toolbox/path.h>
+#include <toolbox/strint.h>
 #include <flipper_format/flipper_format_i.h>
 
 #include "helpers/txrx/subghz_txrx.h"
@@ -9,12 +11,12 @@
 
 #define TAG "SubGhzRemote"
 
-static const char* map_file_labels[SubRemSubKeyNameMaxCount][2] = {
-    [SubRemSubKeyNameUp] = {"UP", "ULABEL"},
-    [SubRemSubKeyNameDown] = {"DOWN", "DLABEL"},
-    [SubRemSubKeyNameLeft] = {"LEFT", "LLABEL"},
-    [SubRemSubKeyNameRight] = {"RIGHT", "RLABEL"},
-    [SubRemSubKeyNameOk] = {"OK", "OKLABEL"},
+static const char* map_file_labels[SubRemSubKeyNameMaxCount][3] = {
+    [SubRemSubKeyNameUp] = {"UP", "ULABEL", "UBUTTON"},
+    [SubRemSubKeyNameDown] = {"DOWN", "DLABEL", "DBUTTON"},
+    [SubRemSubKeyNameLeft] = {"LEFT", "LLABEL", "LBUTTON"},
+    [SubRemSubKeyNameRight] = {"RIGHT", "RLABEL", "RBUTTON"},
+    [SubRemSubKeyNameOk] = {"OK", "OKLABEL", "OKBUTTON"},
 };
 
 void subrem_map_preset_reset(SubRemMapPreset* map_preset) {
@@ -35,13 +37,13 @@ static SubRemLoadMapState subrem_map_preset_check(
     bool all_loaded = true;
     SubRemLoadMapState ret = SubRemLoadMapStateErrorBrokenFile;
 
-    SubRemLoadSubState sub_loadig_state;
+    SubRemLoadSubState sub_loading_state;
     SubRemSubFilePreset* sub_preset;
 
     for(uint8_t i = 0; i < SubRemSubKeyNameMaxCount; i++) {
         sub_preset = map_preset->subs_preset[i];
 
-        sub_loadig_state = SubRemLoadSubStateErrorNoFile;
+        sub_loading_state = SubRemLoadSubStateErrorNoFile;
 
         if(furi_string_empty(sub_preset->file_path)) {
             // FURI_LOG_I(TAG, "Empty file path");
@@ -50,10 +52,10 @@ static SubRemLoadMapState subrem_map_preset_check(
             sub_preset->load_state = SubRemLoadSubStateErrorNoFile;
             FURI_LOG_W(TAG, "Error open file %s", furi_string_get_cstr(sub_preset->file_path));
         } else {
-            sub_loadig_state = subrem_sub_preset_load(sub_preset, txrx, fff_data_file);
+            sub_loading_state = subrem_sub_preset_load(sub_preset, txrx, fff_data_file);
         }
 
-        if(sub_loadig_state != SubRemLoadSubStateOK) {
+        if(sub_loading_state != SubRemLoadSubStateOK) {
             all_loaded = false;
         } else {
             ret = SubRemLoadMapStateNotAllOK;
@@ -95,16 +97,38 @@ static bool subrem_map_preset_load(SubRemMapPreset* map_preset, FlipperFormat* f
         } else {
             ret = true;
         }
+
+        FuriString* button_str = furi_string_alloc();
+        uint16_t button_code = 0;
+
+        // Block does not change ret, value is optional.
+        if(!flipper_format_rewind(fff_data_file)) {
+            // Rewind error
+        } else if (!flipper_format_read_string(fff_data_file, map_file_labels[i][2], button_str)) {
+#ifdef FURI_DEBUG
+            FURI_LOG_W(TAG, "No Button for %s", map_file_labels[i][0]);
+#endif
+        } else if (strint_to_uint16(furi_string_get_cstr(button_str), NULL, &button_code, 16) != StrintParseNoError) {
+#ifdef FURI_DEBUG
+            FURI_LOG_W(TAG, "Invalid Button for %s: %s", map_file_labels[i][0], button_str);
+#endif
+        } else {
+            sub_preset->button = (uint8_t)button_code;
+        }
+
         if(ret) {
             // Preload seccesful
             FURI_LOG_I(
                 TAG,
-                "%-5s: %s %s",
+                "%-5s: %s %s - Btn %s",
                 map_file_labels[i][0],
                 furi_string_get_cstr(sub_preset->label),
-                furi_string_get_cstr(sub_preset->file_path));
+                furi_string_get_cstr(sub_preset->file_path),
+                furi_string_get_cstr(button_str));
             sub_preset->load_state = SubRemLoadSubStatePreloaded;
         }
+
+        furi_string_free(button_str);
 
         flipper_format_rewind(fff_data_file);
     }
@@ -140,9 +164,9 @@ SubRemLoadMapState subrem_map_file_load(SubGhzRemoteApp* app, const char* file_p
     }
 
     if(ret == SubRemLoadMapStateOK) {
-        FURI_LOG_I(TAG, "Load Map File Seccesful");
+        FURI_LOG_I(TAG, "Load Map File Successful");
     } else if(ret == SubRemLoadMapStateNotAllOK) {
-        FURI_LOG_I(TAG, "Load Map File Seccesful [Not all files]");
+        FURI_LOG_I(TAG, "Load Map File Successful [Not all files]");
     } else {
         FURI_LOG_E(TAG, "Broken Map File");
     }
@@ -214,7 +238,7 @@ bool subrem_tx_start_sub(SubGhzRemoteApp* app, SubRemSubFilePreset* sub_preset) 
         FURI_LOG_I(TAG, "Send %s", furi_string_get_cstr(sub_preset->label));
 
         subghz_txrx_load_decoder_by_name_protocol(
-            app->txrx, furi_string_get_cstr(sub_preset->protocaol_name));
+            app->txrx, furi_string_get_cstr(sub_preset->protocol_name));
 
         subghz_txrx_set_preset(
             app->txrx,
@@ -224,6 +248,9 @@ bool subrem_tx_start_sub(SubGhzRemoteApp* app, SubRemSubFilePreset* sub_preset) 
             0);
 #ifndef FW_ORIGIN_Official
         subghz_custom_btns_reset();
+        subghz_txrx_custom_button_reset(app->txrx);
+
+        subghz_txrx_custom_button_set(app->txrx, sub_preset->button);
 #endif
         if(subghz_txrx_tx_start(app->txrx, sub_preset->fff_data) == SubGhzTxRxStartTxStateOk) {
             ret = true;
@@ -238,6 +265,17 @@ bool subrem_tx_stop_sub(SubGhzRemoteApp* app, bool forced) {
     SubRemSubFilePreset* sub_preset = app->map_preset->subs_preset[app->chosen_sub];
 
     if(forced || (sub_preset->type != SubGhzProtocolTypeRAW)) {
+#ifndef FW_ORIGIN_Official
+        if(subghz_custom_btn_get() != SUBGHZ_CUSTOM_BTN_OK) {
+            subghz_custom_btn_set(SUBGHZ_CUSTOM_BTN_OK);
+            subghz_txrx_custom_button_reset(app->txrx);
+
+            // Call deserialize yet another time to restore the original button if a custom button was used
+            subghz_transmitter_deserialize(app->txrx->transmitter, sub_preset->fff_data);
+
+            subghz_custom_btns_reset();
+        }
+#endif
         subghz_txrx_stop(app->txrx);
 #ifndef FW_ORIGIN_Official
         if(sub_preset->type == SubGhzProtocolTypeDynamic) {
@@ -291,8 +329,15 @@ bool subrem_save_map_to_file(SubGhzRemoteApp* app) {
     }
     for(uint8_t i = 0; i < SubRemSubKeyNameMaxCount; i++) {
         sub_preset = app->map_preset->subs_preset[i];
-        if(!furi_string_empty(sub_preset->file_path)) {
+        if(!furi_string_empty(sub_preset->label)) {
             flipper_format_write_string(fff_data, map_file_labels[i][1], sub_preset->label);
+        }
+    }
+
+    for (uint8_t i = 0; i < SubRemSubKeyNameMaxCount; i++) {
+        sub_preset = app->map_preset->subs_preset[i];
+        if(sub_preset->button != 0) {
+            flipper_format_write_hex(fff_data, map_file_labels[i][2], &sub_preset->button, 1);
         }
     }
 

--- a/subghz_remote_app_i.h
+++ b/subghz_remote_app_i.h
@@ -15,6 +15,7 @@
 #include <gui/view_dispatcher.h>
 #include <gui/scene_manager.h>
 #include <gui/modules/submenu.h>
+#include <gui/modules/variable_item_list.h>
 #include <gui/modules/widget.h>
 #include <gui/modules/text_input.h>
 #include <gui/modules/popup.h>
@@ -37,9 +38,11 @@ typedef struct {
     Popup* popup;
     TextInput* text_input;
     Submenu* submenu;
+    VariableItemList* var_item_list;
 
     FuriString* file_path;
     char file_name_tmp[SUBREM_MAX_LEN_NAME];
+    uint8_t button_tmp;
 
     SubRemViewRemote* subrem_remote_view;
     SubRemViewEditMenu* subrem_edit_menu;

--- a/views/edit_menu.c
+++ b/views/edit_menu.c
@@ -1,5 +1,6 @@
 #include "edit_menu.h"
 #include "../subghz_remote_app_i.h"
+#include "../helpers/subrem_custom_button_info.h"
 
 #include <input/input.h>
 #include <gui/elements.h>
@@ -37,6 +38,7 @@ void subrem_view_edit_menu_add_data_to_show(
     uint8_t index,
     FuriString* label,
     FuriString* path,
+    uint8_t button,
     SubRemLoadSubState state) {
     furi_assert(subrem_view_edit_remote);
 
@@ -51,6 +53,9 @@ void subrem_view_edit_menu_add_data_to_show(
                 furi_string_set(model->label, "Empty label");
             }
             furi_string_set(model->file_path, path);
+            if(button != ButtonOK && !furi_string_empty(path)) {
+                furi_string_cat_printf(model->file_path, " (Btn. %s)", custom_button_text[button]);
+            }
             model->sub_state = state;
         },
         true);

--- a/views/edit_menu.h
+++ b/views/edit_menu.h
@@ -24,6 +24,7 @@ void subrem_view_edit_menu_add_data_to_show(
     uint8_t index,
     FuriString* label,
     FuriString* path,
+    uint8_t button,
     SubRemLoadSubState state);
 
 uint8_t subrem_view_edit_menu_get_index(SubRemViewEditMenu* subrem_view_edit_remote);


### PR DESCRIPTION
# What's new

The goal is to bring the app a bit closer to the feature set of the SubGHz app transmitter.

It allows the user to set a custom button that will be used when sending the signal. This custom button is the same that would be sent when pressing the matching button in the SubGHz app transmitter.

This PR obviously includes the config menu, saving and parsing the remote config file.  

# Verification 

- Verify that the file parsing / saving works properly
- Verify that the config menu works properly
- Verify that the transmission of the button works without issue
  - The custom button is properly sent
  - The original button of the .sub file is properly restored when saving the file to update a dynamic code key

Note: I have tested the feature on my FZ running unleashed 082 and with Nice Flor-S codes (these are the only ones I have)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
