### PR TITLE
Add default remote and clear slot features

### DIFF
--- a/helpers/subrem_custom_event.h
+++ b/helpers/subrem_custom_event.h
@@ -13,6 +13,8 @@ typedef enum {
     SubmenuIndexSubRemOpenMapFile = 0,
     SubmenuIndexSubRemEditMapFile,
     SubmenuIndexSubRemNewMapFile,
+    SubmenuIndexSubRemSetDefault,
+    SubmenuIndexSubRemClearDefault,
 #ifdef FURI_DEBUG
     SubmenuIndexSubRemRemoteView,
 #endif

--- a/helpers/subrem_custom_event.h
+++ b/helpers/subrem_custom_event.h
@@ -66,4 +66,5 @@ typedef enum {
     EditSubmenuIndexEditLabel,
     EditSubmenuIndexEditFile,
     EditSubmenuIndexEditButton,
+    EditSubmenuIndexClearSlot,
 } SubRemEditSubmenuIndex;

--- a/scenes/subrem_scene_edit_submenu.c
+++ b/scenes/subrem_scene_edit_submenu.c
@@ -54,6 +54,8 @@ void subrem_scene_edit_submenu_on_enter(void* context) {
     variable_item_set_current_value_index(item, sub_preset->button);
     variable_item_set_current_value_text(item, custom_button_text[sub_preset->button]);
 
+    variable_item_list_add(var_item_list, "Clear Slot", 0, NULL, NULL);
+
     variable_item_list_set_selected_item(
         var_item_list, scene_manager_get_scene_state(app->scene_manager, SubRemSceneEditSubMenu));
 
@@ -72,6 +74,11 @@ bool subrem_scene_edit_submenu_on_event(void* context, SceneManagerEvent event) 
             consumed = true;
         } else if(event.event == SubRemCustomEventEnterEditFile) {
             scene_manager_next_scene(app->scene_manager, SubRemSceneOpenSubFile);
+            consumed = true;
+        } else if(event.event == EditSubmenuIndexClearSlot) {
+            subrem_sub_file_preset_reset(app->map_preset->subs_preset[app->chosen_sub]);
+            app->map_not_saved = true;
+            scene_manager_previous_scene(app->scene_manager);
             consumed = true;
         }
     }

--- a/scenes/subrem_scene_open_map_file.c
+++ b/scenes/subrem_scene_open_map_file.c
@@ -10,6 +10,10 @@ void subrem_scene_open_map_file_on_enter(void* context) {
 
     if(load_state == SubRemLoadMapStateBack) {
         scene_manager_previous_scene(app->scene_manager);
+    } else if(start_scene_state == SubmenuIndexSubRemSetDefault) {
+        // Save selected file as default and go back
+        subrem_save_default_path(furi_string_get_cstr(app->file_path));
+        scene_manager_previous_scene(app->scene_manager);
     } else if(start_scene_state == SubmenuIndexSubRemEditMapFile) {
         scene_manager_set_scene_state(app->scene_manager, SubRemSceneEditMenu, SubRemSubKeyNameUp);
         scene_manager_next_scene(app->scene_manager, SubRemSceneEditMenu);

--- a/scenes/subrem_scene_start.c
+++ b/scenes/subrem_scene_start.c
@@ -39,6 +39,21 @@ void subrem_scene_start_on_enter(void* context) {
         SubmenuIndexSubRemNewMapFile,
         subrem_scene_start_submenu_callback,
         app);
+
+    submenu_add_item(
+        submenu,
+        "Set Default",
+        SubmenuIndexSubRemSetDefault,
+        subrem_scene_start_submenu_callback,
+        app);
+    if(subrem_has_default_path()) {
+        submenu_add_item(
+            submenu,
+            "Clear Default",
+            SubmenuIndexSubRemClearDefault,
+            subrem_scene_start_submenu_callback,
+            app);
+    }
     // submenu_add_item(
     //     submenu,
     //     "About",
@@ -81,6 +96,14 @@ bool subrem_scene_start_on_event(void* context, SceneManagerEvent event) {
             scene_manager_set_scene_state(
                 app->scene_manager, SubRemSceneStart, SubmenuIndexSubRemNewMapFile);
             scene_manager_next_scene(app->scene_manager, SubRemSceneEnterNewName);
+            consumed = true;
+        } else if(event.event == SubmenuIndexSubRemSetDefault) {
+            scene_manager_set_scene_state(
+                app->scene_manager, SubRemSceneStart, SubmenuIndexSubRemSetDefault);
+            scene_manager_next_scene(app->scene_manager, SubRemSceneOpenMapFile);
+            consumed = true;
+        } else if(event.event == SubmenuIndexSubRemClearDefault) {
+            subrem_clear_default_path();
             consumed = true;
         }
         // } else if(event.event == SubmenuIndexSubRemAbout) {

--- a/subghz_remote_app.c
+++ b/subghz_remote_app.c
@@ -188,6 +188,7 @@ int32_t subghz_remote_app(void* arg) {
 #ifdef FW_ORIGIN_Official
     const bool fw_ofw = strcmp(version_get_firmware_origin(version_get()), "Official") == 0;
 #endif
+    // Check for command-line argument first
     if((arg != NULL) && (strlen(arg) != 0)) {
         furi_string_set(subghz_remote_app->file_path, (const char*)arg);
         SubRemLoadMapState load_state = subrem_map_file_load(
@@ -200,8 +201,20 @@ int32_t subghz_remote_app(void* arg) {
             dialog_message_show_storage_error(subghz_remote_app->dialogs, "Cannot load\nmap file");
         }
     }
+    // Try loading default map if no argument provided
+    else if(subrem_load_default_path(subghz_remote_app)) {
+        SubRemLoadMapState load_state = subrem_map_file_load(
+            subghz_remote_app, furi_string_get_cstr(subghz_remote_app->file_path));
+
+        if(load_state == SubRemLoadMapStateOK || load_state == SubRemLoadMapStateNotAllOK) {
+            map_loaded = true;
+        }
+        // If default fails to load, silently fall through to file browser
+    }
 
     if(map_loaded) {
+        // Always push Start scene first so back button returns to menu
+        scene_manager_next_scene(subghz_remote_app->scene_manager, SubRemSceneStart);
         scene_manager_next_scene(subghz_remote_app->scene_manager, SubRemSceneRemote);
     } else {
         furi_string_set(subghz_remote_app->file_path, SUBREM_APP_FOLDER);

--- a/subghz_remote_app_i.c
+++ b/subghz_remote_app_i.c
@@ -312,6 +312,63 @@ SubRemLoadMapState subrem_load_from_file(SubGhzRemoteApp* app) {
     return ret;
 }
 
+bool subrem_load_default_path(SubGhzRemoteApp* app) {
+    furi_assert(app);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperFormat* ff = flipper_format_file_alloc(storage);
+    FuriString* default_path = furi_string_alloc();
+    bool success = false;
+
+    if(flipper_format_file_open_existing(ff, SUBREM_APP_CONFIG)) {
+        if(flipper_format_read_string(ff, "Default", default_path)) {
+            if(!furi_string_empty(default_path)) {
+                furi_string_set(app->file_path, default_path);
+                success = true;
+            }
+        }
+    }
+
+    furi_string_free(default_path);
+    flipper_format_free(ff);
+    furi_record_close(RECORD_STORAGE);
+    return success;
+}
+
+bool subrem_save_default_path(const char* path) {
+    furi_assert(path);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperFormat* ff = flipper_format_file_alloc(storage);
+    bool success = false;
+
+    if(flipper_format_file_open_always(ff, SUBREM_APP_CONFIG)) {
+        if(flipper_format_write_header_cstr(ff, "SubGhzRemote Config", 1)) {
+            if(flipper_format_write_string_cstr(ff, "Default", path)) {
+                success = true;
+            }
+        }
+    }
+
+    flipper_format_free(ff);
+    furi_record_close(RECORD_STORAGE);
+    return success;
+}
+
+bool subrem_clear_default_path(void) {
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    bool success = storage_simply_remove(storage, SUBREM_APP_CONFIG);
+    furi_record_close(RECORD_STORAGE);
+    return success;
+}
+
+bool subrem_has_default_path(void) {
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    bool exists = storage_file_exists(storage, SUBREM_APP_CONFIG);
+    furi_record_close(RECORD_STORAGE);
+    return exists;
+}
+
 bool subrem_save_map_to_file(SubGhzRemoteApp* app) {
     furi_assert(app);
 

--- a/subghz_remote_app_i.h
+++ b/subghz_remote_app_i.h
@@ -26,6 +26,7 @@
 #include <flipper_format/flipper_format_i.h>
 
 #define SUBREM_APP_FOLDER   EXT_PATH("subghz_remote")
+#define SUBREM_APP_CONFIG   EXT_PATH("subghz_remote/.config")
 #define SUBREM_MAX_LEN_NAME 64
 
 typedef struct {
@@ -69,3 +70,11 @@ void subrem_map_preset_reset(SubRemMapPreset* map_preset);
 bool subrem_save_map_to_file(SubGhzRemoteApp* app);
 
 void subrem_save_active_sub(void* context);
+
+bool subrem_load_default_path(SubGhzRemoteApp* app);
+
+bool subrem_save_default_path(const char* path);
+
+bool subrem_clear_default_path(void);
+
+bool subrem_has_default_path(void);


### PR DESCRIPTION
Adds support for setting a default remote that opens automatically when launching the app, plus the ability to clear individual slots in the map editor.

## Changes
### Default Remote Feature:
- App can now auto-load a default map file on startup, skipping the file browser
- New menu options: "Set Default" and "Clear Default" (only shown when a default exists)
- Config stored in /ext/subghz_remote/.config
- Back button from remote view returns to menu (instead of exiting)
### Clear Slot Feature:
- Added "Clear Slot" option in the slot edit menu to remove a .sub file from a slot

## Files touched
- subghz_remote_app_i.h - Config path constant and new function declarations
- subghz_remote_app_i.c - Load/save/clear/check default path functions
- subghz_remote_app.c - Startup logic to load default
- helpers/subrem_custom_event.h - New menu indices
- scenes/subrem_scene_start.c - Set/Clear Default menu items
- scenes/subrem_scene_open_map_file.c - Handle Set Default flow
- scenes/subrem_scene_edit_submenu.c - Clear Slot option